### PR TITLE
Update TrackEditor with new analysis data

### DIFF
--- a/Source/DirectionView.cpp
+++ b/Source/DirectionView.cpp
@@ -70,7 +70,7 @@ void DirectionView::hiResTimerCallback()
 }
 
 
-void DirectionView::updateData()
+void DirectionView::refresh()
 {
     TrackDotComponent* dot;
     

--- a/Source/DirectionView.hpp
+++ b/Source/DirectionView.hpp
@@ -40,7 +40,7 @@ public:
     void hiResTimerCallback() override;
     
     /** Triggers a refresh of the track information. */
-    void updateData();
+    void refresh();
     
     /** Adds a newly-analysed track to be displayed.
      

--- a/Source/LibraryView.cpp
+++ b/Source/LibraryView.cpp
@@ -35,3 +35,10 @@ void LibraryView::loadFiles()
 {
     trackTable->populate(dataManager->getTracks(), dataManager->getNumTracks());
 }
+
+
+void LibraryView::refresh()
+{
+    trackTable->sort();
+    trackEditor->refresh();
+}

--- a/Source/LibraryView.hpp
+++ b/Source/LibraryView.hpp
@@ -30,11 +30,11 @@ public:
     /** Called by the JUCE message when this component is resized - set size/position of child components here. */
     void resized() override;
     
-    /** Triggers the table to be re-sorted - useful when track data has changed. */
-    void refreshTable() { trackTable->sort(); }
-    
     /** Populates the table with tracks from the data manager. */
     void loadFiles();
+    
+    /** Triggers a refresh of the view, which re-sorts the table and tells the track editor to check for new analysis data. */
+    void refresh();
     
 private:
     

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -298,8 +298,8 @@ void MainComponent::timerCallback()
         // Reset the flag
         dataManager->trackDataUpdate.store(false);
         // Tell the Library and Direction view to update
-        libraryView->refreshTable();
-        directionView->updateData();
+        libraryView->refresh();
+        directionView->refresh();
     }
     
     // If we are not on the start screen, and the chosen sample rate is invalid,

--- a/Source/TrackEditor.cpp
+++ b/Source/TrackEditor.cpp
@@ -44,10 +44,13 @@ void TrackEditor::paint(juce::Graphics& g)
 }
 
 
-void TrackEditor::load(Track t)
+void TrackEditor::load(TrackInfo* t)
 {
-    track = t;
+    track = Track();
+    track.info = t;
     track.audio = nullptr;
+    trackAnalysed = t->analysed;
+    
     
 #ifdef SHOW_SEGMENTS
     
@@ -71,4 +74,17 @@ void TrackEditor::load(Track t)
     message = "Loading...";
     
     repaint();
+}
+
+
+void TrackEditor::refresh()
+{
+    if (track.info == nullptr)
+        return;
+    
+    if (!trackAnalysed && track.info->analysed)
+    {
+        waveform->load(&track, true);
+        trackAnalysed = true;
+    }
 }

--- a/Source/TrackEditor.hpp
+++ b/Source/TrackEditor.hpp
@@ -37,7 +37,10 @@ public:
     /** Loads a new track into the editor.
      
      @param[in] track Information on the track to be loaded */
-    void load(Track track);
+    void load(TrackInfo* track);
+    
+    /** Reloads the current track if there is new analysis data present. */
+    void refresh();
     
 private:
     
@@ -50,6 +53,8 @@ private:
     juce::String message; ///< String to display when no track is loaded
     
     std::unique_ptr<AnalyserSegments> analyserSegments; ///< Track segmentation analyser, for debugging of the segmentation algorithm (see SHOW_SEGMENTS macro in .cpp file)
+    
+    bool trackAnalysed = false; ///< Indicates whether the current track had analysis data when it was first loaded, used to check wether a reload is necessary
     
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TrackEditor) ///< JUCE macro to add a memory leak detector

--- a/Source/TrackInfo.cpp
+++ b/Source/TrackInfo.cpp
@@ -56,8 +56,6 @@ int TrackInfo::getBarLength()
 
 int TrackInfo::getLengthSamples()
 {
-    if (!analysed) jassert(false); // Track must be analysed to calculate this!
-    
     return length * SUPPORTED_SAMPLERATE;
 }
 

--- a/Source/TrackTableComponent.cpp
+++ b/Source/TrackTableComponent.cpp
@@ -47,9 +47,7 @@ void TrackTableComponent::resized()
 void TrackTableComponent::cellClicked(int rowNumber, int columnId, const juce::MouseEvent& e)
 {
     TrackInfo* info = tracksSorted.getReference(rowNumber);
-    Track track;
-    track.info = info;
-    trackEditor->load(track);
+    trackEditor->load(info);
 }
 
 


### PR DESCRIPTION
Addressed issue #21 

When an un-analysed track is selected in the Library, the waveform in the TrackEditor will not show a beat grid. If the track is subsequently analysed, the editor will now reload to show the beat grid.